### PR TITLE
overhaul httpc example

### DIFF
--- a/network/http/source/main.c
+++ b/network/http/source/main.c
@@ -5,41 +5,133 @@
 
 #include <3ds.h>
 
-Result http_download(httpcContext *context)//This error handling needs updated with proper text printing once ctrulib itself supports that.
+Result http_download(char *url)
 {
 	Result ret=0;
+	httpcContext context;
+	char *newurl=NULL;
 	u8* framebuf_top;
 	u32 statuscode=0;
-	u32 size=0, contentsize=0;
-	u8 *buf;
+	u32 contentsize=0, readsize=0, size=0;
+	u8 *buf, *lastbuf;
 
-	ret = httpcBeginRequest(context);
-	if(ret!=0)return ret;
-
-	ret = httpcGetResponseStatusCode(context, &statuscode, 0);
-	if(ret!=0)return ret;
-
-	if(statuscode!=200)return -2;
-
-	ret=httpcGetDownloadSizeState(context, NULL, &contentsize);
-	if(ret!=0)return ret;
-
-	printf("size: %"PRId32"\n",contentsize);
+	printf("Downloading %s\n",url);
 	gfxFlushBuffers();
 
-	buf = (u8*)malloc(contentsize);
-	if(buf==NULL)return -1;
-	memset(buf, 0, contentsize);
+	do {
+		ret = httpcOpenContext(&context, HTTPC_METHOD_GET, url, 1);
+		printf("return from httpcOpenContext: %"PRId32"\n",ret);
+		gfxFlushBuffers();
 
+		// This disables SSL cert verification, so https:// will be usable
+		ret = httpcSetSSLOpt(&context, SSLCOPT_DisableVerify);
+		printf("return from httpcSetSSLOpt: %"PRId32"\n",ret);
+		gfxFlushBuffers();
 
-	ret = httpcDownloadData(context, buf, contentsize, NULL);
-	if(ret!=0)
-	{
-		free(buf);
+		// Enable Keep-Alive connections (on by default, pending ctrulib merge)
+		// ret = httpcSetKeepAlive(&context, HTTPC_KEEPALIVE_ENABLED);
+		// printf("return from httpcSetKeepAlive: %"PRId32"\n",ret);
+		// gfxFlushBuffers();
+
+		// Set a User-Agent header so websites can identify your application
+		ret = httpcAddRequestHeaderField(&context, (char*)"User-Agent", (char*)"httpc-example/1.0.0");
+		printf("return from httpcAddRequestHeaderField: %"PRId32"\n",ret);
+		gfxFlushBuffers();
+
+		// Tell the server we can support Keep-Alive connections.
+		// This will delay connection teardown momentarily (typically 5s)
+		// in case there is another request made to the same server.
+		ret = httpcAddRequestHeaderField(&context, (char*)"Connection", (char*)"Keep-Alive");
+		printf("return from httpcAddRequestHeaderField: %"PRId32"\n",ret);
+		gfxFlushBuffers();
+
+		ret = httpcBeginRequest(&context);
+		if(ret!=0){
+			httpcCloseContext(&context);
+			return ret;
+		}
+
+		ret = httpcGetResponseStatusCode(&context, &statuscode, 0);
+		if(ret!=0){
+			httpcCloseContext(&context);
+			return ret;
+		}
+
+		if ((statuscode >= 301 && statuscode <= 303) || (statuscode >= 307 && statuscode <= 308)) {
+			newurl = malloc(0x1000); // One 4K page for new URL
+			if (newurl==NULL){
+				httpcCloseContext(&context);
+				return -1;
+			}
+			ret = httpcGetResponseHeader(&context, (char*)"Location", newurl, 0x1000);
+			url = newurl; // Change pointer to the url that we just learned
+			printf("redirecting to url: %s\n",url);
+			httpcCloseContext(&context); // Close this context before we try the next
+		}
+	} while ((statuscode >= 301 && statuscode <= 303) || (statuscode >= 307 && statuscode <= 308));
+
+	if(statuscode!=200){
+		printf("URL returned status: %"PRId32"\n", statuscode);
+		httpcCloseContext(&context);
+		if(newurl!=NULL) free(newurl);
+		return -2;
+	}
+
+	// This relies on an optional Content-Length header and may be 0
+	ret=httpcGetDownloadSizeState(&context, NULL, &contentsize);
+	if(ret!=0){
+		httpcCloseContext(&context);
+		if(newurl!=NULL) free(newurl);
 		return ret;
 	}
 
-	size = contentsize;
+	printf("reported size: %"PRId32"\n",contentsize);
+	gfxFlushBuffers();
+
+	// Start with a single page buffer
+	buf = (u8*)malloc(0x1000);
+	if(buf==NULL){
+		httpcCloseContext(&context);
+		if(newurl!=NULL) free(newurl);
+		return -1;
+	}
+
+	do {
+		// This download loop resizes the buffer as data is read.
+		ret = httpcDownloadData(&context, buf+size, 0x1000, &readsize);
+		size += readsize; 
+		if (ret == (s32)HTTPC_RESULTCODE_DOWNLOADPENDING){
+				lastbuf = buf; // Save the old pointer, in case realloc() fails.
+				buf = realloc(buf, size + 0x1000);
+				if(buf==NULL){ 
+					httpcCloseContext(&context);
+					free(lastbuf);
+					if(newurl!=NULL) free(newurl);
+					return -1;
+				}
+			}
+	} while (ret == (s32)HTTPC_RESULTCODE_DOWNLOADPENDING);	
+
+	if(ret!=0){
+		httpcCloseContext(&context);
+		if(newurl!=NULL) free(newurl);
+		free(buf);
+		return -1;
+	}
+
+	// Resize the buffer back down to our actual final size
+	lastbuf = buf;
+	buf = realloc(buf, size);
+	if(buf==NULL){ // realloc() failed.
+		httpcCloseContext(&context);
+		free(lastbuf);
+		if(newurl!=NULL) free(newurl);
+		return -1;
+	}
+
+	printf("downloaded size: %"PRId32"\n",size);
+	gfxFlushBuffers();
+
 	if(size>(240*400*3*2))size = 240*400*3*2;
 
 	framebuf_top = gfxGetFramebuffer(GFX_TOP, GFX_LEFT, NULL, NULL);
@@ -55,7 +147,9 @@ Result http_download(httpcContext *context)//This error handling needs updated w
 	gfxSwapBuffers();
 	gspWaitForVBlank();
 
+	httpcCloseContext(&context);
 	free(buf);
+	if (newurl!=NULL) free(newurl);
 
 	return 0;
 }
@@ -63,30 +157,16 @@ Result http_download(httpcContext *context)//This error handling needs updated w
 int main()
 {
 	Result ret=0;
-	httpcContext context;
-
 	gfxInitDefault();
-	httpcInit(0);
+	httpcInit(0); // Buffer size when POST/PUT.
 
 	consoleInit(GFX_BOTTOM,NULL);
 
-	//Change this to your own URL.
-	char *url = "http://devkitpro.org/misc/httpexample_rawimg.rgb";
-
-	printf("Downloading %s\n",url);
+	ret=http_download("http://devkitpro.org/misc/httpexample_rawimg.rgb");
+	// Try the following for redirection to the above URL.
+	// ret=http_download("http://tinyurl.com/hd8jwqx");
+	printf("return from http_download: %"PRId32"\n",ret);
 	gfxFlushBuffers();
-
-	ret = httpcOpenContext(&context, HTTPC_METHOD_GET, url, 1);
-	printf("return from httpcOpenContext: %"PRId32"\n",ret);
-	gfxFlushBuffers();
-
-	if(ret==0)
-	{
-		ret=http_download(&context);
-		printf("return from http_download: %"PRId32"\n",ret);
-		gfxFlushBuffers();
-		httpcCloseContext(&context);
-	}
 
 	// Main loop
 	while (aptMainLoop())


### PR DESCRIPTION
The existing http:c example has extensive design flaws in it, this rewrite provides an overall better example that works much better.

This can handle chunked encoding, CGI content, url redirection, and dynamic/streaming download, and gives examples providing a User-Agent header, and using Keep-Alive to avoid teardown and rebuild of every connection.
