### PR TITLE
Update Opus example README, Makefile with suggested fixes

### DIFF
--- a/audio/opus-decoding/Makefile
+++ b/audio/opus-decoding/Makefile
@@ -50,14 +50,14 @@ CFLAGS	:=	-g -Wall -O2 -mword-relocations \
 			-ffunction-sections \
 			$(ARCH)
 
-CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS `arm-none-eabi-pkg-config opusfile --cflags`
+CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS `$(PREFIX)pkg-config opusfile --cflags`
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lctru -lm `arm-none-eabi-pkg-config opusfile --libs` 
+LIBS	:= -lctru -lm `$(PREFIX)pkg-config opusfile --libs` 
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/audio/opus-decoding/README.md
+++ b/audio/opus-decoding/README.md
@@ -11,14 +11,19 @@ You can install the necessary packages with the following command:
 pacman -S 3ds-opusfile 3ds-pkg-config
 ```
 
+Note that on some systems, you may need to use `dkp-pacman` instead of `pacman`, and you may need to prefix the installation commands with `sudo`.
+
 Additionally, if you do not already have `pkg-config` installed on your *host system*, you will need to install it using your package manager.
 
-On Windows and macOS:
+On Windows:
 ```bash
-dkp-pacman -S pkg-config
+pacman -S pkg-config
 ```
 
-Note that on some systems, you may need to use `dkp-pacman` instead of `pacman`, and you may need to prefix the installation commands with `sudo`.
+On macOS:
+```bash
+sudo dkp-pacman -S pkg-config
+```
 
 ## Further reading
 


### PR DESCRIPTION
Replaces hardcoded `arm-none-eabi-pkg-config` w/ `$(PREFIX)pkg-config`.
Also fixes the instructions for `pkg-config` installation on Win/macOS.

Signed-off-by: Lauren Kelly <lauren.kelly@msn.com>