### PR TITLE
Fixed likely typo in frequency for streaming example

### DIFF
--- a/audio/streaming/source/main.c
+++ b/audio/streaming/source/main.c
@@ -15,7 +15,7 @@ void fill_buffer(void *audioBuffer,size_t offset, size_t size, int frequency ) {
 
 	u32 *dest = (u32*)audioBuffer;
 
-	for (int i=0; i<size; i++) {
+	for (size_t i=0; i<size; i++) {
 
 		s16 sample = INT16_MAX * sin(frequency*(2*M_PI)*(offset+i)/SAMPLERATE);
 
@@ -60,8 +60,8 @@ int main(int argc, char **argv) {
 	ndspChnSetMix(0, mix);
 
 	int notefreq[] = {
-		262, 294, 339, 349, 392, 440,
-		494, 440, 392, 349, 339, 294
+		262, 294, 330, 349, 392, 440,
+		494, 440, 392, 349, 330, 294
 	};
 
 	int note = 4;


### PR DESCRIPTION
The 3rd and 11th note in the array of frequencies are `339`. All other frequencies correspond to the notes of a C major scale rounded to the nearest integer (C4 to B4). It is quite likely that this was intended to be written as `329` (`329.628` truncated). Changed the frequency to `330` so it is consistent with the rest of the frequencies (E4 rounded to the nearest integer).

Also changed the for loop to use `size_t` instead of `int` because it is being compared with `size_t`.