### PR TITLE
Fixing QtmTrackingData according to latest libctru and adding build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,14 @@
 Examples for 3DS using devkitARM, libctru and citro3d
 
 <p align="center"><a href="http://creativecommons.org/publicdomain/mark/1.0/"><img src="http://i.creativecommons.org/p/mark/1.0/88x31.png" alt="Public Domain Mark"></a></p>
+
+## Build instructions
+
+[Box2d](https://github.com/erincatto/box2d), [OpusFile](https://opus-codec.org/) and [ModPlug](http://modplug-xmms.sourceforge.net/) are already built for 3DS using [pacman packages](https://github.com/devkitPro/pacman-packages/tree/master/3ds).
+
+Compile all of the examples above using (either with `dkp-pacman` or `pacman`):
+
+```bash
+sudo pacman -S 3ds-box2d 3ds-opusfile 3ds-libmodplug
+make
+```

--- a/qtm/eye_position/source/main.c
+++ b/qtm/eye_position/source/main.c
@@ -5,7 +5,7 @@
 
 void printTrackingData(const QtmTrackingData *data)
 {
-	printf("Flags:                 %d, %d, %d, %d      \n", data->eyesTracked, data->faceDetected, data->eyesDetected, data->clamped);
+	printf("Flags:                 %d, %d, %d, %d      \n", data->headTracked, data->faceDetected, data->eyesDetected, data->clamped);
 	printf("Confidence level:      %.4f         \n\n", data->confidenceLevel);
 
 	printf("Left eye X (cam):     % .4f        \n", data->eyeCameraCoordinates[QTM_EYE_LEFT][0]);


### PR DESCRIPTION
**qtm/eye-position**

Updated the `eyeTracked` field according to [libctru](https://github.com/devkitPro/libctru/blob/master/libctru/include/3ds/services/qtm.h#L173)

**build instructions**

Added build instructions, especially for Physics Example (cf. [forum](https://devkitpro.org/viewtopic.php?t=9361)), as tools are already provided in [pacman packages](https://github.com/devkitpro/pacman-packages)